### PR TITLE
Data Transfer Constants updated

### DIFF
--- a/librina/include/librina/configuration.h
+++ b/librina/include/librina/configuration.h
@@ -586,6 +586,12 @@ public:
         void set_qos_id_length(unsigned short qos_id_length);
         unsigned short get_sequence_number_length() const;
         void set_sequence_number_length(unsigned short sequence_number_length);
+        unsigned short get_ctrl_sequence_number_length() const;
+        void set_ctrl_sequence_number_length(unsigned short ctrl_sequence_number_length);
+        unsigned short get_rate_length() const;
+        void set_rate_length(unsigned short rate_length);
+        unsigned short get_frame_length() const;
+        void set_frame_length(unsigned short frame_length);
 #endif
         bool isInitialized();
         const std::string toString();
@@ -602,6 +608,10 @@ public:
         /// The length of the sequence number field in the DTP PCI, in bytes
         unsigned short sequence_number_length_;
 
+        /// The length of the control sequence number field in the DTCP PCI, in
+	// bytes
+        unsigned short ctrl_sequence_number_length_;
+
         /// The length of the address field in the DTP PCI, in bytes
         unsigned short address_length_;
 
@@ -610,6 +620,12 @@ public:
 
         /// The maximum length allowed for a PDU in this DIF, in bytes
         unsigned int max_pdu_size_;
+
+        /// The length of the rate field in the DTP PCI, in bytes
+        unsigned short rate_length_;
+
+        /// The length of the frame field in the DTP PCI, in bytes
+        unsigned short frame_length_;
 
         /// True if the PDUs in this DIF have CRC, TTL, and/or encryption. Since
         /// headers are encrypted, not just user data, if any flow uses encryption,

--- a/librina/src/configuration.cc
+++ b/librina/src/configuration.cc
@@ -990,6 +990,22 @@ void DataTransferConstants::set_length_length(unsigned short length_length) {
 	length_length_ = length_length;
 }
 
+unsigned short DataTransferConstants::get_rate_length() const {
+	return rate_length_;
+}
+
+void DataTransferConstants::set_rate_length(unsigned short rate_length) {
+	rate_length_ = rate_length;
+}
+
+unsigned short DataTransferConstants::get_frame_length() const {
+	return frame_length_;
+}
+
+void DataTransferConstants::set_frame_length(unsigned short frame_length) {
+	frame_length_ = frame_length;
+}
+
 unsigned int DataTransferConstants::get_max_pdu_lifetime() const {
 	return max_pdu_lifetime_;
 }
@@ -1028,6 +1044,14 @@ unsigned short DataTransferConstants::get_sequence_number_length() const {
 
 void DataTransferConstants::set_sequence_number_length(unsigned short sequence_number_length) {
 	sequence_number_length_ = sequence_number_length;
+}
+
+unsigned short DataTransferConstants::get_ctrl_sequence_number_length() const {
+	return ctrl_sequence_number_length_;
+}
+
+void DataTransferConstants::set_ctrl_sequence_number_length(unsigned short ctrl_sequence_number_length) {
+	ctrl_sequence_number_length_ = ctrl_sequence_number_length;
 }
 
 bool DataTransferConstants::isInitialized() {

--- a/librina/src/netlink-parsers.cc
+++ b/librina/src/netlink-parsers.cc
@@ -3936,6 +3936,8 @@ int putDataTransferConstantsObject(nl_msg* netlinkMessage,
         NLA_PUT_U16(netlinkMessage, DTC_ATTR_CEP_ID, object.get_cep_id_length());
         NLA_PUT_U16(netlinkMessage, DTC_ATTR_SEQ_NUM,
                         object.get_sequence_number_length());
+        NLA_PUT_U16(netlinkMessage, DTC_ATTR_CTRL_SEQ_NUM,
+                        object.get_ctrl_sequence_number_length());
         NLA_PUT_U16(netlinkMessage, DTC_ATTR_ADDRESS,
                         object.get_address_length());
         NLA_PUT_U16(netlinkMessage, DTC_ATTR_LENGTH, object.get_length_length());
@@ -3943,6 +3945,10 @@ int putDataTransferConstantsObject(nl_msg* netlinkMessage,
                         object.get_max_pdu_size());
         NLA_PUT_U32(netlinkMessage, DTC_ATTR_MAX_PDU_LIFE,
                                 object.get_max_pdu_lifetime());
+        NLA_PUT_U16(netlinkMessage, DTC_ATTR_RATE,
+                                object.get_rate_length());
+        NLA_PUT_U16(netlinkMessage, DTC_ATTR_FRAME,
+                                object.get_frame_length());
         if (object.is_dif_integrity()){
                 NLA_PUT_FLAG(netlinkMessage, DTC_ATTR_DIF_INTEGRITY);
         }
@@ -6562,6 +6568,12 @@ DataTransferConstants * parseDataTransferConstantsObject(nlattr *nested) {
         attr_policy[DTC_ATTR_MAX_PDU_LIFE].type = NLA_U32;
         attr_policy[DTC_ATTR_MAX_PDU_LIFE].minlen = 4;
         attr_policy[DTC_ATTR_MAX_PDU_LIFE].maxlen = 4;
+        attr_policy[DTC_ATTR_RATE].type = NLA_U16;
+        attr_policy[DTC_ATTR_RATE].minlen = 2;
+        attr_policy[DTC_ATTR_RATE].maxlen = 2;
+        attr_policy[DTC_ATTR_FRAME].type = NLA_U16;
+        attr_policy[DTC_ATTR_FRAME].minlen = 2;
+        attr_policy[DTC_ATTR_FRAME].maxlen = 2;
         attr_policy[DTC_ATTR_DIF_INTEGRITY].type = NLA_FLAG;
         attr_policy[DTC_ATTR_DIF_INTEGRITY].minlen = 0;
         attr_policy[DTC_ATTR_DIF_INTEGRITY].maxlen = 0;
@@ -6595,6 +6607,11 @@ DataTransferConstants * parseDataTransferConstantsObject(nlattr *nested) {
                                 nla_get_u16(attrs[DTC_ATTR_SEQ_NUM]));
         }
 
+        if (attrs[DTC_ATTR_CTRL_SEQ_NUM]) {
+                result->set_ctrl_sequence_number_length(
+                                nla_get_u16(attrs[DTC_ATTR_CTRL_SEQ_NUM]));
+        }
+
         if (attrs[DTC_ATTR_ADDRESS]) {
                 result->set_address_length(nla_get_u16(attrs[DTC_ATTR_ADDRESS]));
         }
@@ -6611,6 +6628,16 @@ DataTransferConstants * parseDataTransferConstantsObject(nlattr *nested) {
         if (attrs[DTC_ATTR_MAX_PDU_LIFE]) {
                 result->set_max_pdu_lifetime(
                                 nla_get_u32(attrs[DTC_ATTR_MAX_PDU_LIFE]));
+        }
+
+        if (attrs[DTC_ATTR_RATE]) {
+                result->set_rate_length(
+                                nla_get_u16(attrs[DTC_ATTR_RATE]));
+        }
+
+        if (attrs[DTC_ATTR_FRAME]) {
+                result->set_frame_length(
+                                nla_get_u16(attrs[DTC_ATTR_FRAME]));
         }
 
         if (attrs[DTC_ATTR_DIF_INTEGRITY]) {

--- a/librina/src/netlink-parsers.h
+++ b/librina/src/netlink-parsers.h
@@ -457,10 +457,13 @@ enum DataTransferConstantsAttributes {
         DTC_ATTR_PORT_ID,
         DTC_ATTR_CEP_ID,
         DTC_ATTR_SEQ_NUM,
+        DTC_ATTR_CTRL_SEQ_NUM,
         DTC_ATTR_ADDRESS,
         DTC_ATTR_LENGTH,
         DTC_ATTR_MAX_PDU_SIZE,
         DTC_ATTR_MAX_PDU_LIFE,
+        DTC_ATTR_RATE,
+        DTC_ATTR_FRAME,
         DTC_ATTR_DIF_INTEGRITY,
         __DTC_ATTR_MAX,
 };

--- a/librina/test/test-netlink-parsers.cc
+++ b/librina/test/test-netlink-parsers.cc
@@ -1287,11 +1287,14 @@ int testIpcmAssignToDIFRequestMessage() {
 	dataTransferConstants.set_cep_id_length(2);
 	dataTransferConstants.set_dif_integrity(true);
 	dataTransferConstants.set_length_length(3);
+	dataTransferConstants.set_rate_length(4);
+	dataTransferConstants.set_frame_length(4);
 	dataTransferConstants.set_max_pdu_lifetime(4);
 	dataTransferConstants.set_max_pdu_size(5);
 	dataTransferConstants.set_port_id_length(6);
 	dataTransferConstants.set_qos_id_length(7);
 	dataTransferConstants.set_sequence_number_length(8);
+	dataTransferConstants.set_ctrl_sequence_number_length(9);
 	efcpConfiguration.set_data_transfer_constants(dataTransferConstants);
 	QoSCube * qosCube = new QoSCube("cube 1", 1);
 	efcpConfiguration.add_qos_cube(qosCube);
@@ -1372,6 +1375,20 @@ int testIpcmAssignToDIFRequestMessage() {
                                 << " are different\n";
                 returnValue = -1;
         } else if (message.getDIFInformation().get_dif_configuration().get_efcp_configuration().
+        		get_data_transfer_constants().get_rate_length() !=
+                                        recoveredMessage->getDIFInformation().get_dif_configuration().
+                                        get_efcp_configuration().get_data_transfer_constants().get_rate_length()) {
+                std::cout << "DIFInformation.DIFConfiguration.dtc.rateLength on original and recovered messages"
+                                << " are different\n";
+                returnValue = -1;
+        } else if (message.getDIFInformation().get_dif_configuration().get_efcp_configuration().
+        		get_data_transfer_constants().get_frame_length() !=
+                                        recoveredMessage->getDIFInformation().get_dif_configuration().
+                                        get_efcp_configuration().get_data_transfer_constants().get_frame_length()) {
+                std::cout << "DIFInformation.DIFConfiguration.dtc.frameLength on original and recovered messages"
+                                << " are different\n";
+                returnValue = -1;
+        } else if (message.getDIFInformation().get_dif_configuration().get_efcp_configuration().
         		get_data_transfer_constants().get_max_pdu_lifetime() !=
                                         recoveredMessage->getDIFInformation().get_dif_configuration().
                                         get_efcp_configuration().get_data_transfer_constants().get_max_pdu_lifetime()) {
@@ -1404,6 +1421,13 @@ int testIpcmAssignToDIFRequestMessage() {
                                         recoveredMessage->getDIFInformation().get_dif_configuration().
                                         get_efcp_configuration().get_data_transfer_constants().get_sequence_number_length()) {
                 std::cout << "DIFInformation.DIFConfiguration.dtc.seqNumLength on original and recovered messages"
+                                << " are different\n";
+                returnValue = -1;
+        } else if (message.getDIFInformation().get_dif_configuration().get_efcp_configuration().
+        		get_data_transfer_constants().get_ctrl_sequence_number_length() !=
+                                        recoveredMessage->getDIFInformation().get_dif_configuration().
+                                        get_efcp_configuration().get_data_transfer_constants().get_ctrl_sequence_number_length()) {
+                std::cout << "DIFInformation.DIFConfiguration.dtc.ctrlSeqNumLength on original and recovered messages"
                                 << " are different\n";
                 returnValue = -1;
         } else if (message.getDIFInformation().get_dif_configuration().get_efcp_configuration().

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -70,6 +70,9 @@ struct dt_cons {
         /* The length of the sequence number field in the DTP PCI, in bytes */
         u_int16_t seq_num_length;
 
+        /* The length of the sequence number field in the DTCP PCI, in bytes */
+        u_int16_t ctrl_seq_num_length;
+
         /* The maximum length allowed for a PDU in this DIF, in bytes */
         u_int32_t max_pdu_size;
 
@@ -80,10 +83,10 @@ struct dt_cons {
         u_int32_t max_pdu_life;
 
         /* Rate for rate based mechanism. */
-        u_int32_t rate;
+        u_int16_t rate_length;
 
         /* Time frame for rate based mechanism. */
-        u_int32_t frame;
+        u_int16_t frame_length;
 
         /*
          * True if the PDUs in this DIF have CRC, TTL, and/or encryption.

--- a/linux/net/rina/rnl-utils.c
+++ b/linux/net/rina/rnl-utils.c
@@ -1332,6 +1332,8 @@ static int parse_dt_cons(struct nlattr *  attr,
         attr_policy[DTC_ATTR_CEP_ID].len           = 2;
         attr_policy[DTC_ATTR_SEQ_NUM].type         = NLA_U16;
         attr_policy[DTC_ATTR_SEQ_NUM].len          = 2;
+        attr_policy[DTC_ATTR_CTRL_SEQ_NUM].type    = NLA_U16;
+        attr_policy[DTC_ATTR_CTRL_SEQ_NUM].len     = 2;
         attr_policy[DTC_ATTR_ADDRESS].type         = NLA_U16;
         attr_policy[DTC_ATTR_ADDRESS].len          = 2;
         attr_policy[DTC_ATTR_LENGTH].type          = NLA_U16;
@@ -1340,6 +1342,10 @@ static int parse_dt_cons(struct nlattr *  attr,
         attr_policy[DTC_ATTR_MAX_PDU_SIZE].len     = 4;
         attr_policy[DTC_ATTR_MAX_PDU_LIFE].type    = NLA_U32;
         attr_policy[DTC_ATTR_MAX_PDU_LIFE].len     = 4;
+        attr_policy[DTC_ATTR_RATE].type            = NLA_U16;
+        attr_policy[DTC_ATTR_RATE].len             = 2;
+        attr_policy[DTC_ATTR_FRAME].type           = NLA_U16;
+        attr_policy[DTC_ATTR_FRAME].len            = 2;
         attr_policy[DTC_ATTR_DIF_INTEGRITY].type   = NLA_FLAG;
         attr_policy[DTC_ATTR_DIF_INTEGRITY].len    = 0;
 
@@ -1362,6 +1368,10 @@ static int parse_dt_cons(struct nlattr *  attr,
                 dt_cons->seq_num_length =
                         nla_get_u16(attrs[DTC_ATTR_SEQ_NUM]);
 
+        if (attrs[DTC_ATTR_CTRL_SEQ_NUM])
+                dt_cons->ctrl_seq_num_length =
+                        nla_get_u16(attrs[DTC_ATTR_CTRL_SEQ_NUM]);
+
         if (attrs[DTC_ATTR_ADDRESS])
                 dt_cons->address_length =
                         nla_get_u16(attrs[DTC_ATTR_ADDRESS]);
@@ -1378,9 +1388,13 @@ static int parse_dt_cons(struct nlattr *  attr,
                 dt_cons->max_pdu_life =
                         nla_get_u32(attrs[DTC_ATTR_MAX_PDU_LIFE]);
 
-        /* FIXME: To modify once this field are supported by rnl. */
-        dt_cons->rate = 4;
-        dt_cons->frame = 4;
+        if (attrs[DTC_ATTR_RATE])
+                dt_cons->rate_length =
+                        nla_get_u16(attrs[DTC_ATTR_RATE]);
+
+        if (attrs[DTC_ATTR_FRAME])
+                dt_cons->frame_length =
+                        nla_get_u16(attrs[DTC_ATTR_FRAME]);
 
         dt_cons->dif_integrity = nla_get_flag(attrs[DTC_ATTR_DIF_INTEGRITY]);
 

--- a/linux/net/rina/rnl-utils.h
+++ b/linux/net/rina/rnl-utils.h
@@ -418,10 +418,13 @@ enum data_transfer_cons_attrs_list {
         DTC_ATTR_PORT_ID,
         DTC_ATTR_CEP_ID,
         DTC_ATTR_SEQ_NUM,
+        DTC_ATTR_CTRL_SEQ_NUM,
         DTC_ATTR_ADDRESS,
         DTC_ATTR_LENGTH,
         DTC_ATTR_MAX_PDU_SIZE,
         DTC_ATTR_MAX_PDU_LIFE,
+        DTC_ATTR_RATE,
+        DTC_ATTR_FRAME,
         DTC_ATTR_DIF_INTEGRITY,
         __DTC_ATTR_MAX,
 };

--- a/rinad/etc/default.dif
+++ b/rinad/etc/default.dif
@@ -6,7 +6,10 @@
     	"lengthLength" : 2,
     	"portIdLength" : 2,
     	"qosIdLength" : 2,
+    	"rateLength" : 4,
+    	"frameLength" : 4,
     	"sequenceNumberLength" : 4,
+    	"ctrlSequenceNumberLength" : 4,
     	"maxPduSize" : 10000,
     	"maxPduLifetime" : 60000
     },

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -615,11 +615,14 @@ const rina::SerializedObject* DataTransferConstantsEncoder::encode(const void* o
 	gpb_dtc.set_cepidlength(dtc->cep_id_length_);
 	gpb_dtc.set_difintegrity(dtc->dif_integrity_);
 	gpb_dtc.set_lengthlength(dtc->length_length_);
+	gpb_dtc.set_ratelength(dtc->rate_length_);
+	gpb_dtc.set_framelength(dtc->frame_length_);
 	gpb_dtc.set_maxpdulifetime(dtc->max_pdu_lifetime_);
 	gpb_dtc.set_maxpdusize(dtc->max_pdu_size_);
 	gpb_dtc.set_portidlength(dtc->port_id_length_);
 	gpb_dtc.set_qosidlength(dtc->qos_id_length_);
 	gpb_dtc.set_sequencenumberlength(dtc->sequence_number_length_);
+	gpb_dtc.set_ctrlsequencenumberlength(dtc->ctrl_sequence_number_length_);
 
 	int size = gpb_dtc.ByteSize();
 	char *serialized_message = new char[size];
@@ -643,11 +646,14 @@ void* DataTransferConstantsEncoder::decode(
 	dtc->cep_id_length_ = gpb_dtc.cepidlength();
 	dtc->dif_integrity_ = gpb_dtc.difintegrity();
 	dtc->length_length_ = gpb_dtc.lengthlength();
+	dtc->rate_length_ = gpb_dtc.ratelength();
+	dtc->frame_length_ = gpb_dtc.framelength();
 	dtc->max_pdu_lifetime_ = gpb_dtc.maxpdulifetime();
 	dtc->max_pdu_size_ = gpb_dtc.maxpdusize();
 	dtc->port_id_length_ = gpb_dtc.portidlength();
 	dtc->qos_id_length_ = gpb_dtc.qosidlength();
 	dtc->sequence_number_length_ = gpb_dtc.sequencenumberlength();
+	dtc->ctrl_sequence_number_length_ = gpb_dtc.ctrlsequencenumberlength();
 
 	return (void*) dtc;
 }

--- a/rinad/src/common/encoders/DataTransferConstantsMessage.proto
+++ b/rinad/src/common/encoders/DataTransferConstantsMessage.proto
@@ -1,19 +1,22 @@
 package rina.messages;
 option optimize_for = LITE_RUNTIME;
 
-message dataTransferConstants_t{					//Specifies the constants for EFCP to use
-	optional uint32 maxPDUSize = 1;					//The maximum size of a PDU, in bytes
-	optional uint32 addressLength = 2;				//The length of the address field in EFCP PDUs, in bytes
-	optional uint32 portIdLength = 3;					//The length of the portId field in EFCP PDUs, in bytes
-	optional uint32 cepIdLength = 4;					//The length of the Connection Endpoint Id field in EFCP PDUs, in bytes
-	optional uint32 qosidLength = 5;					//The length of the QoS id field in EFCP PDUs, in bytes
-	optional uint32 sequenceNumberLength = 6;			//The length of the sequenceNumber field in EFCP PDUs, in bytes
-	optional uint32 lengthLength = 7;					//The length of the length field in EFCP PDUs, in bytes
+message dataTransferConstants_t{				//Specifies the constants for EFCP to use
+	optional uint32 maxPDUSize = 1;				//The maximum size of a PDU, in bytes
+	optional uint32 addressLength = 2;			//The length of the address field in EFCP PDUs, in bytes
+	optional uint32 portIdLength = 3;			//The length of the portId field in EFCP PDUs, in bytes
+	optional uint32 cepIdLength = 4;			//The length of the Connection Endpoint Id field in EFCP PDUs, in bytes
+	optional uint32 qosidLength = 5;			//The length of the QoS id field in EFCP PDUs, in bytes
+	optional uint32 sequenceNumberLength = 6;		//The length of the sequenceNumber field in EFCP PDUs, in bytes
+	optional uint32 lengthLength = 7;			//The length of the length field in EFCP PDUs, in bytes
 	optional uint64 seqRolloverThreshold = 8;		//The sequence number after which the Flow Allocator instance should create a new EFCP connection
-	optional uint32 maxPDULifetime = 9;				//The maximum time a PDU can "live" within the DIF, in milliseconds
+	optional uint32 maxPDULifetime = 9;			//The maximum time a PDU can "live" within the DIF, in milliseconds
 	optional bool DIFConcatenation = 10;			//This is true if multiple SDUs can be delimited and concatenated within a single PDU
 	optional bool DIFFragmentation = 11;			//This is true if multiple SDUs can be fragmented and reassembled within a single PDU
-	optional bool DIFIntegrity = 12;				//True if the PDUs in this DIF have CRC, TTL, and/or encryption
-    optional uint32 maxTimeToKeepRetransmitting = 13;            //The maximum time DTCP will try to keep retransmitting a PDU, before discarding it. This is R in delta-T
-    optional uint32 maxTimeToACK = 14;                      //The maximum time the receiving side of a DTCP connection will take to ACK a PDU once it has received it. This is A in delta-T
+	optional bool DIFIntegrity = 12;			//True if the PDUs in this DIF have CRC, TTL, and/or encryption
+	optional uint32 maxTimeToKeepRetransmitting = 13;	//The maximum time DTCP will try to keep retransmitting a PDU, before discarding it. This is R in delta-T
+	optional uint32 maxTimeToACK = 14;			//The maximum time the receiving side of a DTCP connection will take to ACK a PDU once it has received it. This is A in delta-T
+	optional uint32 rateLength = 15;			//The length of the rate field in the FC PDUs (for rate based flows)
+	optional uint32 frameLength = 16;			//The length of the frame field in the FC PDUs (for rate based flows)
+	optional uint32 ctrlSequenceNumberLength = 17;		//The length of the ctrlSequenceNumber field in EFCP(DTCP) PDUs, in bytes
 }

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -562,6 +562,14 @@ rinad::DIFTemplate * parse_dif_template_config(const Json::Value & root,
 		(dt_const
 				.get("lengthLength", 0)
 				.asUInt());
+		dt.rate_length_ = static_cast<unsigned short>
+		(dt_const
+				.get("rateLength", 0)
+				.asUInt());
+		dt.frame_length_ = static_cast<unsigned short>
+		(dt_const
+				.get("frameLength", 0)
+				.asUInt());
 		dt.max_pdu_lifetime_ = dt_const
 				.get("maxPduLifetime", 0)
 				.asUInt();
@@ -581,6 +589,11 @@ rinad::DIFTemplate * parse_dif_template_config(const Json::Value & root,
 				static_cast<unsigned short>
 		(dt_const
 				.get("sequenceNumberLength", 0)
+				.asUInt());
+		dt.ctrl_sequence_number_length_ =
+				static_cast<unsigned short>
+		(dt_const
+				.get("ctrlSequenceNumberLength", 0)
 				.asUInt());
 		dif_template->dataTransferConstants = dt;
 	}

--- a/rinad/src/ipcm/dif-validator.cc
+++ b/rinad/src/ipcm/dif-validator.cc
@@ -120,8 +120,11 @@ bool DIFConfigValidator::dataTransferConstants() {
 		      data_trans_config.port_id_length_ != 0 &&
 		      data_trans_config.cep_id_length_ != 0 &&
 		      data_trans_config.sequence_number_length_ != 0 &&
+		      data_trans_config.ctrl_sequence_number_length_ != 0 &&
 		      data_trans_config.length_length_ != 0 &&
 		      data_trans_config.max_pdu_size_ != 0 &&
+		      data_trans_config.rate_length_ != 0 &&
+		      data_trans_config.frame_length_ != 0 &&
 		      data_trans_config.max_pdu_lifetime_ != 0;
 	if (!result)
 		LOG_ERR("Data Transfer Constants configuration failed");

--- a/rinad/src/ipcp/test-encoders.cc
+++ b/rinad/src/ipcp/test-encoders.cc
@@ -174,11 +174,14 @@ bool test_data_transfer_constants(rinad::Encoder * encoder) {
 	dtc.cep_id_length_ = 15;
 	dtc.dif_integrity_ = true;
 	dtc.length_length_ = 12;
+	dtc.rate_length_ = 5;
+	dtc.frame_length_ = 3;
 	dtc.max_pdu_lifetime_ = 45243;
 	dtc.max_pdu_size_ = 1233;
 	dtc.port_id_length_ = 541;
 	dtc.qos_id_length_ = 3414;
 	dtc.sequence_number_length_ = 123;
+	dtc.ctrl_sequence_number_length_ = 482;
 
 	rina::CDAPMessage cdapMessage = rina::CDAPMessage();
 	cdapMessage.obj_class_ = rinad::EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_CLASS;
@@ -202,6 +205,14 @@ bool test_data_transfer_constants(rinad::Encoder * encoder) {
 		return false;
 	}
 
+	if (dtc.rate_length_ != recovered_obj->rate_length_) {
+		return false;
+	}
+
+	if (dtc.frame_length_ != recovered_obj->frame_length_) {
+		return false;
+	}
+
 	if (dtc.max_pdu_lifetime_ != recovered_obj->max_pdu_lifetime_) {
 		return false;
 	}
@@ -219,6 +230,10 @@ bool test_data_transfer_constants(rinad::Encoder * encoder) {
 	}
 
 	if (dtc.sequence_number_length_ != recovered_obj->sequence_number_length_) {
+		return false;
+	}
+
+	if (dtc.ctrl_sequence_number_length_ != recovered_obj->ctrl_sequence_number_length_) {
 		return false;
 	}
 


### PR DESCRIPTION
@kewinrausch : It just not been tested, it just compiles and passes librina and rinad make check tests. Please merge and test to include in the original PR and proceed.


- DataTransferConstants class in librina and dt_cons struct in the kernel
  updated to contain missing constants:
   - rate field length in DTCP PDUs
   - frame field length in DTCP PDUs
   - contrl sequence numbers length in DTCP PDUs

- DIF template validator and configuration files updated to use new cons.
- GPB encoders updated
- RNL layer updated to handle the corresponding updated messages.
- serdes module updated to use dt_cons struct and no harcoded values.